### PR TITLE
fix match entry points after importlib metadata upgrade

### DIFF
--- a/raincoat/match/__init__.py
+++ b/raincoat/match/__init__.py
@@ -76,7 +76,12 @@ def check_matches(matches):
 
 
 def get_match_entrypoints():
-    return importlib_metadata.entry_points()["raincoat.match"]
+    entry_points = importlib_metadata.entry_points()
+    try:
+        return entry_points["raincoat.match"]
+    except KeyError:
+        # The old way of getting entry points was deprecated in importlib_metadata v5.0.0
+        return importlib_metadata.entry_points(group='raincoat.match')
 
 
 def compute_match_types():


### PR DESCRIPTION
## Purpose

Release `v5.0.0` of `importlib_metadata` has broken the way entry points are retrieved from `setup.cfg` by deprecating the old API that we were using.

## Proposal

Add the new way of getting entry points in a try/except so that we continue supporting old versions of `importlib_metada`

Closes #32

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
- [ ] (Maintainers: add PR labels)
